### PR TITLE
Versión 1.1.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,12 +2,13 @@ filter:
   excluded_paths:
     - 'tests/'
     - 'vendor/'
+    - 'tools/'
 
 build:
   dependencies:
     override:
       - composer self-update --no-interaction --no-progress
-      - composer install --no-interaction --no-progress
+      - composer upgrade --no-interaction --no-progress --prefer-dist
   nodes:
     analysis:
       tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 # php compatibility
-php: ['7.3', '7.4']
+php: ['7.3', '7.4', '8.0']
 
 cache:
   - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - travis_retry composer install --no-interaction --no-progress --prefer-dist
+  - travis_retry composer upgrade --no-interaction --no-progress --prefer-dist
   - bash develop/install-development-tools
 
 script:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,73 +1,84 @@
-# Contributor Covenant Code of Conduct
+# Código de Conducta convenido para Contribuyentes
 
-## Our Pledge
+## Nuestro compromiso
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+Nosotros, como miembros, contribuyentes y administradores nos comprometemos a hacer de la participación en nuestra comunidad una experiencia libre de acoso para todo el mundo, independientemente de la edad, dimensión corporal, minusvalía visible o invisible, etnicidad, características sexuales, identidad y expresión de género, nivel de experiencia, educación, nivel socioeconómico, nacionalidad, apariencia personal, raza, religión, o identidad u orientación sexual.
 
-## Our Standards
+Nos comprometemos a actuar e interactuar de maneras que contribuyan a una comunidad abierta, acogedora, diversa, inclusiva y sana.
 
-Examples of behavior that contributes to creating a positive environment
-include:
+## Nuestros estándares
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+Ejemplos de comportamiento que contribuyen a crear un ambiente positivo para nuestra comunidad:
 
-Examples of unacceptable behavior by participants include:
+* Demostrar empatía y amabilidad ante otras personas
+* Respeto a diferentes opiniones, puntos de vista y experiencias
+* Dar y aceptar adecuadamente retroalimentación constructiva
+* Aceptar la responsabilidad y disculparse ante quienes se vean afectados por nuestros errores, aprendiendo de la experiencia
+* Centrarse en lo que sea mejor no solo para nosotros como individuos, sino para la comunidad en general
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+Ejemplos de comportamiento inaceptable:
 
-## Our Responsibilities
+* El uso de lenguaje o imágenes sexualizadas, y aproximaciones o
+  atenciones sexuales de cualquier tipo
+* Comentarios despectivos (_trolling_), insultantes o derogatorios, y ataques personales o políticos
+* El acoso en público o privado
+* Publicar información privada de otras personas, tales como direcciones físicas o de correo
+  electrónico, sin su permiso explícito
+* Otras conductas que puedan ser razonablemente consideradas como inapropiadas en un
+  entorno profesional
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+## Aplicación de las responsabilidades
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Los administradores de la comunidad son responsables de aclarar y hacer cumplir nuestros estándares de comportamiento aceptable y tomarán acciones apropiadas y correctivas de forma justa en respuesta a cualquier comportamiento que consideren inapropiado, amenazante, ofensivo o dañino.
 
-## Scope
+Los administradores de la comunidad tendrán el derecho y la responsabilidad de eliminar, editar o rechazar comentarios, _commits_, código, ediciones de páginas de wiki, _issues_ y otras contribuciones que no se alineen con este Código de Conducta, y comunicarán las razones para sus decisiones de moderación cuando sea apropiado.
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+## Alcance
 
-## Enforcement
+Este código de conducta aplica tanto a espacios del proyecto como a espacios públicos donde un individuo esté en representación del proyecto o comunidad. Ejemplos de esto incluyen el uso de la cuenta oficial de correo electrónico, publicaciones a través de las redes sociales oficiales, o presentaciones con personas designadas en eventos en línea o no.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at eclipxe13@gmail.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+## Aplicación
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [INSERTAR MÉTODO DE CONTACTO]. Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
 
-## Attribution
+Todos los administradores de la comunidad están obligados a respetar la privacidad y la seguridad de quienes reporten incidentes.
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+## Guías de Aplicación
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+Los administradores de la comunidad seguirán estas Guías de Impacto en la Comunidad para determinar las consecuencias de cualquier acción que juzguen como un incumplimiento de este Código de Conducta:
+
+### 1. Corrección
+
+**Impacto en la Comunidad**: El uso de lenguaje inapropiado u otro comportamiento considerado no profesional o no acogedor en la comunidad.
+
+**Consecuencia**: Un aviso escrito y privado por parte de los administradores de la comunidad, proporcionando claridad alrededor de la naturaleza de este incumplimiento y una explicación de por qué el comportamiento es inaceptable. Una disculpa pública podría ser solicitada.
+
+### 2. Aviso
+
+**Impacto en la Comunidad**: Un incumplimiento causado por un único incidente o por una cadena de acciones.
+
+**Consecuencia**: Un aviso con consecuencias por comportamiento prolongado. No se interactúa con las personas involucradas, incluyendo interacción no solicitada con quienes se encuentran aplicando el Código de Conducta, por un periodo especificado de tiempo. Esto incluye evitar las interacciones en espacios de la comunidad, así como a través de canales externos como las redes sociales. Incumplir estos términos puede conducir a una expulsión temporal o permanente.
+
+### 3. Expulsión temporal
+
+**Impacto en la Comunidad**: Una serie de incumplimientos de los estándares de la comunidad, incluyendo comportamiento inapropiado continuo.
+
+**Consecuencia**: Una expulsión temporal de cualquier forma de interacción o comunicación pública con la comunidad durante un intervalo de tiempo especificado. No se permite interactuar de manera pública o privada con las personas involucradas, incluyendo interacciones no solicitadas con quienes se encuentran aplicando el Código de Conducta, durante este periodo. Incumplir estos términos puede conducir a una expulsión permanente.
+
+### 4. Expulsión permanente
+
+**Impacto en la Comunidad**: Demostrar un patrón sistemático de incumplimientos de los estándares de la comunidad, incluyendo conductas inapropiadas prolongadas en el tiempo, acoso de individuos, o agresiones o menosprecio a grupos de individuos.
+
+**Consecuencia**: Una expulsión permanente de cualquier tipo de interacción pública con la comunidad del proyecto.
+
+## Atribución
+
+Este Código de Conducta es una adaptación del [Contributor Covenant][homepage], versión 2.0,
+disponible en <https://www.contributor-covenant.org/es/version/2/0/code_of_conduct.html>.
+
+Las Guías de Impacto en la Comunidad están inspiradas en la [escalera de aplicación del código de conducta de Mozilla](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+Para respuestas a las preguntas frecuentes de este código de conducta, consulta las FAQ en <https://www.contributor-covenant.org/faq>.
+Hay traducciones disponibles en <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,107 +1,86 @@
-# Contributing
+# Contribuciones
 
-Contributions are welcome. We accept pull requests on [GitHub](https://github.com/phpcfdi/rfc).
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en [el repositorio GitHub][homepage].
 
-This project adheres to a
-[Contributor Code of Conduct](https://github.com/phpcfdi/rfc/blob/master/CODE_OF_CONDUCT.md).
-By participating in this project and its community, you are expected to uphold this code.
+Este proyecto se apega al siguiente [Código de Conducta][coc].
+Al participar en este proyecto y en su comunidad, deberás seguir este código.
 
-## Team members
+## Miembros del equipo
 
-* [Carlos C Soto](https://github.com/eclipxe13) - original author and maintainer
-* [GitHub constributors](https://github.com/phpcfdi/rfc/graphs/contributors)
+* [phpCfdi][] - Organización que mantiene el proyecto.
+* [Contribuidores][contributors].
 
-## Communication Channels
+## Canales de comunicación
 
-You can find help and discussion in the following places:
+Puedes encontrar ayuda y comentar asuntos relacionados con este proyecto en estos lugares:
 
+* Comunidad Discord: <https://discord.gg/aFGYXvX>
 * GitHub Issues: <https://github.com/phpcfdi/rfc/issues>
 
-## Reporting Bugs
+## Reportar Bugs
 
-Bugs are tracked in our project's [issue tracker](https://github.com/phpcfdi/rfc/issues).
+Publica los *Bugs* en la sección [GitHub Issues][issues] del proyecto.
 
-When submitting a bug report, please include enough information for us to reproduce the bug.
-A good bug report includes the following sections:
+Sigue las recomendaciones generales de [phpCfdi][] para reportar problemas
+<https://www.phpcfdi.com/general/reportar-problemas/>.
 
-* Expected outcome
-* Actual outcome
-* Steps to reproduce, including sample code
-* Any other information that will help us debug and reproduce the issue, including stack traces, system/environment information, and screenshots
+Cuando se reporte un *Bug*, por favor incluye la mayor información posible para reproducir el problema, preferentemente
+con ejemplos de código o cualquier otra información técnica que nos pueda ayudar a identificar el caso.
 
-**Please do not include passwords or any personally identifiable information in your bug report and sample code.**
+**Recuerda no incluir contraseñas, información personal o confidencial.**
 
-## Fixing Bugs
+## Corrección de Bugs
 
-We welcome pull requests to fix bugs!
+Apreciamos mucho los *Pull Request* para corregir Bugs.
 
-If you see a bug report that you'd like to fix, please feel free to do so.
-Following the directions and guidelines described in the "Adding New Features"
-section below, you may create bugfix branches and send us pull requests.
+Si encuentras un reporte de Bug y te gustaría solucionarlo siéntete libre de hacerlo.
+Sigue las directrices de "Agregar nuevas funcionalidades" a continuación.
 
-## Adding New Features
+## Agregar nuevas funcionalidades
 
-If you have an idea for a new feature, it's a good idea to check out our
-[issues](https://github.com/phpcfdi/rfc/issues) or active
-[pull requests](https://github.com/phpcfdi/rfc/pulls)
-first to see if the feature is already being worked on.
-If not, feel free to submit an issue first, asking whether the feature is beneficial to the project.
-This will save you from doing a lot of development work only to have your feature rejected.
-We don't enjoy rejecting your hard work, but some features just don't fit with the goals of the project.
+Si tienes una idea para una nueva funcionalidad revisa primero que existan discusiones o *Pull Requests*
+en donde ya se esté trabajando en la funcionalidad.
 
-When you do begin working on your feature, here are some guidelines to consider:
+Antes de trabajar en la nueva característica, utiliza los "Canales de comunicación" mencionados
+anteriormente para platicar acerca de tu idea. Si dialogas tus ideas con la comunidad y los
+mantenedores del proyecto, podrás ahorrar mucho esfuerzo de desarrollo y prevenir que tu
+*Pull Request* sea rechazado. No nos gusta rechazar contribuciones, pero algunas características
+o la forma de desarrollarlas puede que no estén alineadas con el proyecto.
 
-* Your pull request description should clearly detail the changes you have made.
-* Follow our code style using `squizlabs/php_codesniffer` and `friendsofphp/php-cs-fixer`.
-* Please **write tests** for any new features you add.
-* Please **ensure that tests pass** before submitting your pull request. We have Travis CI automatically running tests for pull requests. However, running the tests locally will help save time.
-* **Use topic/feature branches.** Please do not ask us to pull from your master branch.
-* **Submit one feature per pull request.** If you have multiple features you wish to submit, please break them up into separate pull requests.
-* **Send coherent history**. Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+Considera las siguientes directrices:
 
-## Installing development tools
+* Usa una rama única que se desprenda de la rama principal.
+  No mezcles dos diferentes funcionalidades en una misma rama o *Pull Request*.
+* Describe claramente y en detalle los cambios que hiciste.
+* **Escribe pruebas** para la funcionalidad que deseas agregar.
+* **Asegúrate que las pruebas pasan** antes de enviar tu contribución.
+  Usamos integración contínua donde se hace esta verificación, pero es mucho mejor si lo pruebas localmente.
+* Intenta enviar una historia coherente, entenderemos cómo cambia el código si los *commits* tienen significado.
+* La documentación es parte del proyecto.
+  Realiza los cambios en los archivos de ayuda para que reflejen los cambios en el código.
 
-This project uses different development tools to ensure code style, test and quality (using code analyzers).
+## Proceso de construcción
 
 ```shell
-# install project direct dependences
-composer install
-
-# install development tools dependences (using composer script)
+# Actualiza tus dependencias
+composer update
 composer dev:install
 
-# install development tools dependences (using installer script)
-bash develop/install-development-tools
-```
+# Verificación de estilo de código
+composer dev:check-style
 
-## Check the code style
-
-If you are having issues with coding standars use `php-cs-fixer` and `phpcbf`
-
-```shell
-# using composer
+# Corrección de estilo de código
 composer dev:fix-style
 
-# or using tools individually
-tools/php-cs-fixer fix -v
-tools/phpcbf -sp src/ tests/
-```
+# Ejecución de pruebas
+composer dev:test
 
-## Running Tests
-
-The following tests must pass before we will accept a pull request.
-If any of these do not pass, it will result in a complete build failure.
-Before you can run these, be sure to `composer install` or `composer update`.
-
-```shell
-# using composer
+# Ejecución todo en uno: corregir estilo, verificar estilo y correr pruebas
 composer dev:build
-
-# or using tools individually
-tools/phpcs -sp src/ tests/
-tools/php-cs-fixer fix -v --dry-run
-vendor/bin/phpunit --coverage-text
-tools/phpstan analyze --level max src/ tests/
-tools/psalm
-phpdbg -qrr tools/infection --show-mutations
 ```
+
+[phpCfdi]:      https://github.com/phpcfdi/
+[project]:      https://github.com/phpcfdi/rfc
+[contributors]: https://github.com/phpcfdi/rfc/graphs/contributors
+[coc]:          https://github.com/phpcfdi/rfc/blob/master/CODE_OF_CONDUCT.md
+[issues]:       https://github.com/phpcfdi/rfc/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Carlos C Soto
+Copyright (c) 2020 - 2021 PhpCfdi https://www.phpcfdi.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Si se desea saber que el RFC es genérico se puede usar el método `Rfc::isGener
 ## Generador de RFC
 
 Es común usar generadores (ficticios) de datos, esta librería provee la clase `RfcFaker` que se puede utilizar
-por sí sola o en conjunto con [`fzaninotto/Faker`](https://github.com/fzaninotto/Faker).
+por sí sola o en conjunto con [`FakerPHP/Faker`](https://github.com/FakerPHP/Faker).
 
 Provee métodos para crear una cadena de caracteres que es una clave RFC:
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 [![Coverage Status][badge-coverage]][coverage]
 [![Total Downloads][badge-downloads]][downloads]
 
-> PHP library to deal with Mexican RFC
+> Librería de PHP para trabajar con RFC.
 
-:us: The documentation of this project is in spanish as this is the natural language for intented audience.
+:us: The documentation of this project is in spanish as this is the natural language for the intended audience.
 
 ## Acerca de 
 
 En México, toda persona física o moral para realizar cualquier actividad económica requiere de un registro
-ante la Secrcetaría de Hacienda y Crédito Público (SHCP) llamado Registro Federal de Contribuyentes (RFC).
+ante la Secretaría de Hacienda y Crédito Público (SHCP) llamado Registro Federal de Contribuyentes (RFC).
 
 Esta librería permite trabajar con esta clave desde el aplicativo de PHP.
 
@@ -55,7 +55,7 @@ No se puede crear un objeto a partir del constructor `new Rfc`. Use `Rfc::unpars
 
 Se recomienda que siempre que se crea el objeto pero los datos de origen no son de confianza se utilice `Rfc::parse`.
 
-El único dato importante dentro del RFC es la cadena de cacateres misma. Por ello se ha implementado que la conversión
+El único dato importante dentro del RFC es la cadena de caracteres misma. Por ello se ha implementado que la conversión
 a cadena de caracteres y la exportación a JSON devuelvan específicamente este dato.
 
 ## Números de serie
@@ -73,7 +73,7 @@ de conversión por lo que su ejecución es lo más veloz que puede ser.
 ## RFC genérico y foráneo
 
 Es frecuente utilizar RFC que son *virtuales*, por ejemplo, para operaciones sin identificar como una
-venta de mostrador u operaciones con extrajeros, en estos casos están las constantes
+venta de mostrador u operaciones con extranjeros, en estos casos están las constantes
 `Rfc::RFC_GENERIC = 'XAXX010101000'` y `Rfc::RFC_FOREIGN = 'XEXX010101000'` respectivamente.
 
 Puede usar los métodos `Rfc::newGeneric()` y `Rfc::newForeign()` para crear instancias con estos datos.
@@ -93,7 +93,7 @@ Provee métodos para crear una cadena de caracteres que es una clave RFC:
 
 ## Desarrollo
 
-Para entender esta librería a nivel de desarrollo (para extender o modificar), lee los siguientes documentos:
+Para entender esta librería en el ámbito de desarrollo (para extender o modificar), lee los siguientes documentos:
 
 - [Entorno de desarrollo](develop/EntornoDesarrollo.md).
 - [Consideraciones generales de la librería](develop/Generales.md).
@@ -107,7 +107,7 @@ Puedes obtener soporte abriendo un ticker en Github.
 Adicionalmente, esta librería pertenece a la comunidad [PhpCfdi](https://www.phpcfdi.com), así que puedes usar los
 mismos canales de comunicación para obtener ayuda de algún miembro de la comunidad.
 
-## Compatilibilidad
+## Compatibilidad
 
 Esta librería se mantendrá compatible con al menos la versión con
 [soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.
@@ -118,7 +118,7 @@ sin temor a romper tu aplicación.
 ## Contribuciones
 
 Las contribuciones con bienvenidas. Por favor lee [CONTRIBUTING][] para más detalles
-y recuerda revisar el archivo de tareas pendientes [TODO][] y el [CHANGELOG][].
+y recuerda revisar el archivo de tareas pendientes [TODO][] y el archivo [CHANGELOG][].
 
 ## Copyright and License
 

--- a/composer.json
+++ b/composer.json
@@ -38,20 +38,19 @@
         "dev:install": [
             "bash develop/install-development-tools"
         ],
-        "dev:build": ["@dev:fix-style", "@dev:test"],
+        "dev:build": ["@dev:fix-style", "@dev:check-style", "@dev:test"],
         "dev:check-style": [
-            "tools/php-cs-fixer fix --dry-run --verbose",
-            "tools/phpcs --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php tools/phpcs --colors -sp src/ tests/"
         ],
         "dev:fix-style": [
-            "tools/php-cs-fixer fix --verbose",
-            "tools/phpcbf --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --verbose",
+            "@php tools/phpcbf --colors -sp src/ tests/"
         ],
         "dev:test": [
-            "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "tools/phpstan analyse --no-progress --level max src/ tests/",
-            "tools/psalm --no-progress"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php tools/phpstan analyse --no-progress --level max src/ tests/",
+            "@php tools/psalm --no-progress"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --testdox --coverage-html build/coverage/html/"
@@ -59,10 +58,10 @@
     },
     "scripts-descriptions": {
         "dev:install": "DEV: install development tools into tools/",
-        "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
+        "dev:build": "DEV: run dev:fix-style, dev:check-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run phplint, dev:check-style, phpunit, phpstan and psalm",
+        "dev:test": "DEV: run phpunit, phpstan and psalm",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.1",
-        "fzaninotto/faker": "^1.9"
+        "phpunit/phpunit": "^9.5",
+        "fakerphp/faker": "^1.13"
     },
     "autoload": {
         "psr-4": {

--- a/develop/ConversionEntero.md
+++ b/develop/ConversionEntero.md
@@ -2,29 +2,29 @@
 
 La clave RFC se compone de 4 partes: `[Siglas] + [Fecha] + [Homoclave] + [Verificador]`.
 
-Las `[Siglas]` son 4 o 3 caracteres dependiendo si se trata de una persona física (4) o moral (3).
-Además dw que incluyen las letras, se incluye el `&` y `Ñ`, siendo la *eñe* un caracter de 2 bytes.
+El campo `[Siglas]` son 4 o 3 caracteres dependiendo si se trata de una persona física (4) o moral (3).
+Además dw que incluyen las letras, se incluye `&` y `Ñ`, siendo la *eñe* un símbolo de 2 bytes.
 
-La `[Fecha]` es todo un tema, pues no usa 4 dígitos para el año, solo usa 2, luego entonces `000229` es inválido
+El campo `[Fecha]` es todo un tema, pues no usa 4 dígitos para el año, solo usa 2, luego entonces `000229` es inválido
 para `1900-02-29` pero válido para `2000-02-29`.
 
-La `[Homoclave]` en realidad incluye al dígito verificador, pero por el momento lo separaremos, básicamente porque
+El campo `[Homoclave]` en realidad incluye al dígito verificador, pero por el momento lo separaremos, básicamente porque
 los caracteres que pueden incluirse son diferentes, en este caso se incluyen números y letras pero sin `&` ni `Ñ`.
 
-El `[Verificador]` es un dígito calculado, pero no hay un estándar publicado bien definido, y he encontrado que
+El campo `[Verificador]` es un dígito calculado, pero no hay un estándar publicado bien definido, y he encontrado que
 a pesar de las reglas para obtenerlo existen RFC que no cumplen (ni pueden cumplir) dicha regla, es como si el SAT
 simplemente hubiera seguido con el siguiente dígito para un RFC de una misma entidad.
 Los caracteres que lo componen son números y la letra `A`.
 
 Tomando en cuenta las reglas anteriores, tenemos que un RFC como cadena de caracteres puede contener hasta 17 bytes,
-y al momento de trabajar con un gran volúmen de información con este dato como índice pues podría ser bastante lento,
+y al momento de trabajar con un gran volumen de información con este dato como índice pues podría ser bastante lento,
 por ejemplo, en el caso de la lista de "RFC inscritos no cancelados".
 
 Entonces, para resolver este problema, hice un convertidor que utiliza diferentes bases para ir y regresar de un entero.
 
 ## Conversión a bases
 
-Primero se eliminan los multibytes y se acota el universo a sólo mayúsculas.
+Primero se eliminan los multibyte y se acota el universo a solamente mayúsculas.
 Con eso podemos entender las siguientes bases:
 
 | Sigla opcional        | 3 Siglas obligatorias | Fecha                     | 2 Homoclave   | Verificador   |
@@ -35,7 +35,7 @@ Con eso podemos entender las siguientes bases:
 La fecha son 36525 opciones porque hay 25 años bisiestos, si se contara desde `1900-01-01` encontrarás que hay solo 24.
 
 Dado lo anterior, se comporta como cualquier conversión de bases, con la salvedad de que cada grupo tiene un exponente
-calculado en base a sus predecesores y no a su posición (porque las bases son diferentes).
+calculado con base en sus predecesores y no a su posición (porque las bases son diferentes).
 
 Entonces, los exponentes por grupo son (opción previa × anterior):
 
@@ -58,11 +58,11 @@ Para el RFC `COSC8001137NA` se tiene que hacer la conversión por cada grupo:
 | Grupo   | N1   | N2   | N3   | N4   | Fecha         | H1   | H1   | V    |
 | ---     | ---  | ---  | ---  | ---  | ---           | ---  | ---  | ---  |
 | Valor   | `C`  | `O`  | `S`  | `C`  | `2080-01-13`  | `7`  | `N`  | `A`  | 
-| Entrero | `3`  | `14` | `18` | `2`  | `29,232`      | `7`  | `23` | `10` |
+| Entero  | `3`  | `14` | `18` | `2`  | `29,232`      | `7`  | `23` | `10` |
 
 Haciendo la suma de la multiplicación del valor entero por los exponentes, el número de serie es: `40,270,344,269,627`.
 
-La primer `C` tiene un valor de `3` porque la primer opción es `0 => <vacío>`,
+La primera letra `C` tiene un valor de `3` porque la primera opción es `0 => <vacío>`,
 a diferencia de la segunda `C` con valor `2` porque en ese grupo el primer valor es `0 => A`.
 
 Para regresar de la representación impresa se hace un ejercicio semejante pero utilizando el módulo según su base,

--- a/develop/EntornoDesarrollo.md
+++ b/develop/EntornoDesarrollo.md
@@ -1,6 +1,6 @@
 # Entorno de desarrollo
 
-Para tener un entorno de desarrollo totalmente funcional considera los siguiente pasos:
+Para tener un entorno de desarrollo totalmente funcional considera los siguientes pasos:
 
 - Obtén el proyecto
 
@@ -18,4 +18,30 @@ composer install
 
 ```
 composer dev:install
+```
+
+Al hacer las modificaciones, considera estos comandos útiles
+
+- Verificación de estilo de código
+
+```
+composer dev:check-style
+```
+
+- Corrección de estilo de código
+
+```
+composer dev:fix-style
+```
+
+- Ejecución de pruebas
+
+```
+composer dev:test
+```
+
+- Ejecución todo en uno: corregir estilo, verificar estilo y correr pruebas
+
+```
+composer dev:build
 ```

--- a/develop/Generales.md
+++ b/develop/Generales.md
@@ -2,7 +2,7 @@
 
 ## Uso de `final`
 
-No deberías tener ningún motivo para necesitar extender las clases que aquí de proponen.
+No deberías tener ningún motivo para necesitar extender las clases que aquí se proponen.
 
 Lo que te recomiendo es que utilices el patrón de diseño *Proxy*
 <https://designpatternsphp.readthedocs.io/en/latest/Structural/Proxy/README.html>
@@ -12,14 +12,14 @@ Lo que te recomiendo es que utilices el patrón de diseño *Proxy*
 Partamos por los siguientes hechos:
 
 - Un objeto creado debería tener un estado válido.
-- Revisar si una clave RFC es válida es "costosa", se tiene que umplir una expresión regular compleja
+- Revisar si una clave RFC es válida es "costosa", se tiene que cumplir una expresión regular compleja
   además de revisar que la fecha contenga un dato válido.
 
 Por lo anterior, resulta costoso *siempre* tener que validar si una clave RFC es válida,
 si el RFC viene de la conversión de un entero, entonces la clave será válida, no es necesario verificarla.
 
 La clase `Rfc` tiene varios constructores estáticos: para construir el objeto validándolo, para construir el
-objeto a partir de un RFC genérico nacional, o de extrangero, o a partir de un entero.
+objeto a partir de un RFC genérico nacional, o de extranjero, o a partir de un entero.
 
 Así pues, en lugar de permitir `new Rfc(string)` para crear un el objeto con la clave RFC proporcionada,
 preferí darle nombre como constructor estático `Rfc::unparsed(string): self` y así no caer en la falsa idea

--- a/develop/RfcFaker.md
+++ b/develop/RfcFaker.md
@@ -16,10 +16,10 @@ $rfcFisica = $faker->mexicanRfcFisica();
 La forma de crearlo es con un número aleatorio para personas morales, o bien para personas físicas,
 o bien para todo el espectro.
 
-## Integración con `fzaninotto/Faker`
+## Integración con `FakerPHP/Faker`
 
 También se puede usar ese mismo objeto dentro de la librería más común para generación de falsos
- en PHP [`fzaninotto/Faker`](https://github.com/fzaninotto/Faker).
+ en PHP [`FakerPHP/Faker`](https://github.com/FakerPHP/Faker).
 
 ```php
 $faker = new Faker\Generator();

--- a/develop/RfcFaker.md
+++ b/develop/RfcFaker.md
@@ -2,7 +2,7 @@
 
 En algunas ocasiones puede resultar útil inventarse RFC, por ejemplo, al estar haciendo pruebas.
 
-Para generar claves RFC inventadas (*fakes*) se puede utilizar la clase `RfcFaker` que ṕuede crear un RFC
+Para generar claves RFC inventadas (*fakes*) se puede utilizar la clase `RfcFaker` que puede crear un RFC
 cualquiera `RfcFaker::mexicanRfc()` o de persona moral `RfcFaker::mexicanRfcMoral()`
 o de persona física `RfcFaker::mexicanRfcFisica()`.
 
@@ -20,7 +20,7 @@ o bien para todo el espectro.
 
 También se puede usar ese mismo objeto dentro de la librería más común para generación de falsos
  en PHP [`fzaninotto/Faker`](https://github.com/fzaninotto/Faker).
- 
+
 ```php
 $faker = new Faker\Generator();
 $faker->addProvider(new PhpCfdi\Rfc\RfcFaker());

--- a/develop/install-development-tools
+++ b/develop/install-development-tools
@@ -1,21 +1,84 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 
-TOOLS_DIR=tools
+# install-development-tools
+# Optional environment variables:
+#   TOOLS_DIR: where tools will be installed, defaults to "tools"
+#
+# Version: 0.0.20201110
+# Author: Carlos C Soto
+#
+# This scripts install a set of development tools and install them on a directory
+# The tools must be available on GitHub
+# The tool must be a single file
+# The online tool version is extracted from GitHub HTTP Location header
+# The current version is stored on a .tool-name.version file
 
-function install_from_github() {
-  local destination="${TOOLS_DIR}/${3}"
-  if [ -f "$destination" ]; then
-    rm "$destination"
-  fi
-  wget "https://github.com/${1}/releases/latest/download/${2}" -O "${TOOLS_DIR}/${3}"
-  chmod +x "$destination"
+function github_online_version() {
+    curl -s -I "$1" | grep -i ^location | awk '{print $2}' | xargs dirname | xargs basename
 }
 
+function install_on() {
+    local github_url="${1}"
+    local destination="${2}"
+    local version_file="${3}"
+    local version_content="${4}"
+
+    curl --location --output "$destination" "$github_url"
+    echo "$version_content" >"$version_file"
+    chmod +x "$destination"
+}
+
+function upgrade_from_github() {
+    local github_url="${1}"
+    local destination="${2}"
+    local version_file="${3}"
+    local current_version="$(cat "$version_file")"
+    local online_version="$(github_online_version "$github_url")"
+
+    echo -n "Upgrade $destination: "
+    if [ "$current_version" == "$online_version" ]; then
+        echo "already on $current_version"
+        return 0
+    fi
+
+    echo -n "from $current_version to $online_version ... "
+    install_on "$github_url" "$destination" "$version_file" "$online_version"
+    echo "OK"
+    return 0
+}
+
+function install_from_github() {
+    local github_url="${1}"
+    local destination="${2}"
+    local version_file="${3}"
+    local current_version="$(github_online_version "$github_url")"
+
+    echo -n "Install $destination: version $current_version ... "
+    install_on "$github_url" "$destination" "$version_file" "$current_version"
+    echo "OK"
+    return 0
+}
+
+function install_upgrade() {
+    local destination="${3}"
+    local version_file="$(dirname "${3}")/.$(basename "${3}").version"
+    local github_url="https://github.com/${1}/releases/latest/download/${2}"
+
+    if [ -f "$destination" -a -f "$version_file" ]; then
+        upgrade_from_github "$github_url" "$destination" "$version_file" && return 0
+    fi
+
+    install_from_github "$github_url" "$destination" "$version_file" && return 0
+
+    return 1;
+}
+
+TOOLS_DIR="${TOOLS_DIR:-tools}"
 mkdir -p "$TOOLS_DIR"
 
-install_from_github FriendsOfPHP/PHP-CS-Fixer php-cs-fixer.phar php-cs-fixer
-install_from_github squizlabs/PHP_CodeSniffer phpcbf.phar phpcbf
-install_from_github squizlabs/PHP_CodeSniffer phpcs.phar phpcs
-install_from_github phpstan/phpstan phpstan.phar phpstan
-install_from_github vimeo/psalm psalm.phar psalm
-install_from_github infection/infection infection.phar infection
+install_upgrade FriendsOfPHP/PHP-CS-Fixer php-cs-fixer.phar "${TOOLS_DIR}/php-cs-fixer"
+install_upgrade squizlabs/PHP_CodeSniffer phpcbf.phar "${TOOLS_DIR}/phpcbf"
+install_upgrade squizlabs/PHP_CodeSniffer phpcs.phar "${TOOLS_DIR}/phpcs"
+install_upgrade phpstan/phpstan phpstan.phar "${TOOLS_DIR}/phpstan"
+install_upgrade vimeo/psalm psalm.phar "${TOOLS_DIR}/psalm"
+install_upgrade infection/infection infection.phar "${TOOLS_DIR}/infection"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,4 +6,4 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 ## Version 1.0
 
-- Versión inicial
+- Versión inicial.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
-## Version 1.0
+## Versión 1.1.0
+
+Dependencias:
+
+- Se cambia la dependencia `fzaninotto/Faker` a `FakerPHP/Faker`.
+
+Documentación:
+
+- Se modifica la documentación del proyecto en español, además de revisar textos actuales.
+- Se pone la licencia correcta de *Carlos C Soto* a *PhpCfdi* con el año 2021.
+  
+Desarrollo:
+
+- Se remueve la concatenación innecesaria en la expresión regular del RFC, se explica en comentarios.
+- Se agrega la compatibilidad con PHP 8.0 a la matriz de Travis-CI.
+- Se modifican los scripts de composer para que se ejecuten con el mismo programa de php con el que fueron invocados.
+
+## Version 1.0.0
 
 - Versión inicial.

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -3,7 +3,7 @@
 Respetamos el estándar [Versionado Semántico 2.0.0](https://semver.org/lang/es/).
 
 En resumen, [SemVer](https://semver.org/) es un sistema de versiones de tres componentes `X.Y.Z`
-que nombraremos así: `[ Breaking ] . [ Feature ] . [ Fix ]`, donde:
+que nombraremos así: ` Breaking . Feature . Fix `, donde:
 
 - `Breaking`: Rompe la compatibilidad de código con versiones anteriores.
 - `Feature`: Agrega una nueva característica que es compatible con lo anterior.
@@ -11,7 +11,7 @@ que nombraremos así: `[ Breaking ] . [ Feature ] . [ Fix ]`, donde:
 
 ## Composer
 
-[Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
+La herramienta [Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
 Este gestor usa las [reglas](https://getcomposer.org/doc/articles/versions.md)
 de versionado semántico para instalar y actualizar paquetes.
 
@@ -29,9 +29,6 @@ Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reg
 Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto
 introducen cambios sin previo aviso.
 
-Sin embargo, nos apegaremos a `[ 0 ] . [ Breaking ] . [ Feature || Fix ]`. Lo que significa que `0.3.0`
-no es compatible con `0.2.15` pero `0.3.4` sí es compatible con `0.3.0`.
-
 ## `@internal` no rompe compatibilidad
 
 Si la librería contiene elementos marcados como `@internal` significa que no deben ser utilizados
@@ -42,4 +39,4 @@ Cuando un elemento es `@internal`, dicho elemento:
 
 - no debe ser una entrada (parámetro)
 - no debe ser una salida (retorno)
-- no debe exponer exponer funcionalidades en los objetos públicos (rasgos)
+- no debe exponer funcionalidades en los objetos públicos (rasgos)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,1 +1,3 @@
 # phpcfdi/rfc To Do List
+
+No hay tareas pendientes documentadas.

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0"?>
-<psalm
-    totallyTyped="true"
+<psalm xmlns="https://getpsalm.org/schema/config"
     resolveFromConfigFile="true"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    totallyTyped="true"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/RfcFaker.php
+++ b/src/RfcFaker.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Rfc;
 /**
  * This class creates a random but syntactically valid Rfc string
  *
- * You can use it with `fzaninotto/Faker` library by registering into the faker generator:
+ * You can use it with `FakerPHP/Faker` library by registering into the faker generator:
  * ```php
  * $faker = new Faker\Generator();
  * $faker->addProvider(new PhpCfdi\Rfc\RfcFaker());

--- a/src/RfcParser.php
+++ b/src/RfcParser.php
@@ -44,11 +44,22 @@ final class RfcParser
      */
     public static function parse(string $rfc): self
     {
-        $regex = '/^' // desde el inicio
-            . '(?<name>[A-ZÑ&]{3,4})' // letras y números para el nombre (3 para morales, 4 para físicas)
-            . '(?<year>[0-9]{2})(?<month>[0-9]{2})(?<day>[0-9]{2})' // año mes y día, la validez de la fecha se comprueba después
-            . '(?<hkey>[A-Z0-9]{2})(?<checksum>[A0-9]{1})' // homoclave (letra o dígito 2 veces + A o dígito 1 vez)
-            . '$/u'; // hasta el final, considerar la cadena unicode
+        /*
+         * Explicación de la expresión regular:
+         * - desde el inicio
+         *      /^
+         * - letras y números para el nombre (3 para morales, 4 para físicas)
+         *      (?<name>[A-ZÑ&]{3,4})
+         * - año mes y día, la validez de la fecha se comprueba después
+         *      (?<year>[0-9]{2})(?<month>[0-9]{2})(?<day>[0-9]{2})
+         * - homoclave (letra o dígito 2 veces + A o dígito 1 vez)
+         *      (?<hkey>[A-Z0-9]{2})(?<checksum>[A0-9]{1})
+         * - hasta el final
+         *      $/
+         * - tratamiento unicode
+         *      u
+         */
+        $regex = '/^(?<name>[A-ZÑ&]{3,4})(?<year>[0-9]{2})(?<month>[0-9]{2})(?<day>[0-9]{2})(?<hkey>[A-Z0-9]{2})(?<checksum>[A0-9]{1})$/u';
         if (1 !== preg_match($regex, mb_strtoupper($rfc), $matches)) {
             throw Exceptions\InvalidExpressionToParseException::invalidParts($rfc);
         }


### PR DESCRIPTION
- Se cambia la dependencia `fzaninotto/Faker` a `FakerPHP/Faker`.
- Se modifica la documentación del proyecto en español, además de revisar textos actuales.
- Se pone la licencia correcta de *Carlos C Soto* a *PhpCfdi* con el año 2021.
- Se remueve la concatenación innecesaria en la expresión regular del RFC, se explica en comentarios.
- Se agrega la compatibilidad con PHP 8.0 a la matriz de Travis-CI.
- Se modifican los scripts de composer para que se ejecuten con el mismo programa de php con el que fueron invocados.
