### PR TITLE
Fix php-cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setCacheFile(__DIR__ . '/build/php_cs.cache')
     ->setRules([
@@ -19,7 +19,7 @@ return PhpCsFixer\Config::create()
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
         'no_alias_functions' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
         'new_with_braces' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,7 +19,7 @@ return (new PhpCsFixer\Config())
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
         'no_alias_functions' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
         'new_with_braces' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/tests/Unit/RfcTest.php
+++ b/tests/Unit/RfcTest.php
@@ -106,7 +106,7 @@ final class RfcTest extends TestCase
         $data = ['rfc' => Rfc::unparsed('COSC8001137NA')];
         $this->assertJsonStringEqualsJsonString(
             '{"rfc": "COSC8001137NA"}',
-            json_encode($data) ?: ''
+            json_encode($data) ?: '',
         );
     }
 


### PR DESCRIPTION
Since `php-cs-fixer:^3.0` it has to be updated to a new configuration file and new options.
This PR fixes the build process