### PR TITLE
Mantenimiento 2022-02-23

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 
 # Do not put this files on a distribution package
 /.github/                   export-ignore
+/.phive/                    export-ignore
 /build/                     export-ignore
 /develop/                   export-ignore
 /tests/                     export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.2.1" installed="3.2.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.1" installed="3.6.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.1" installed="3.6.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.1.2" installed="1.1.2" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.12.0" installed="4.12.0" location="./tools/psalm" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.21.0" installed="4.21.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 - 2021 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2020 - 2022 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados no requieren de una nueva versión y son incluidos en la rama principal.
 
+### 2022-02-23 Mantenimiento
+
+- Se actualiza el año en el archivo de licencia. Feliz 2022.
+- Se actualizan las herramientas de desarrollo.
+- Se actualiza el archivo de configuración de Psalm, el atributo `totallyTyped` está deprecado.
+- Se agrega PHP 8.1 a la matriz de pruebas de PHP.
+- Se crea la clase abstracta `PhpCfdi\Rfc\Tests\TestCase` para no depender directamente de `PHPUnit\Framework\TestCase`.
+
 ### 2022-01-12 Mantenimiento
 
 - Se separan los flujos de integración continua en `build` y `coverage`.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm xmlns="https://getpsalm.org/schema/config"
     resolveFromConfigFile="true"
-    totallyTyped="true">
+    errorLevel="1">
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\Rfc\Tests;
+
+abstract class TestCase extends \PHPUnit\Framework\TestCase
+{
+}

--- a/tests/Unit/CheckSumTest.php
+++ b/tests/Unit/CheckSumTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\Rfc\Tests\Unit;
 
 use PhpCfdi\Rfc\CheckSum;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
 final class CheckSumTest extends TestCase
 {

--- a/tests/Unit/Exceptions/InvalidExpressionToParseExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidExpressionToParseExceptionTest.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Rfc\Tests\Unit\Exceptions;
 
 use PhpCfdi\Rfc\Exceptions\InvalidExpressionToParseException;
 use PhpCfdi\Rfc\Exceptions\RfcException;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
 final class InvalidExpressionToParseExceptionTest extends TestCase
 {

--- a/tests/Unit/Exceptions/InvalidIntegerToConvertExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidIntegerToConvertExceptionTest.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Rfc\Tests\Unit\Exceptions;
 
 use PhpCfdi\Rfc\Exceptions\InvalidIntegerToConvertException;
 use PhpCfdi\Rfc\Exceptions\RfcException;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
 final class InvalidIntegerToConvertExceptionTest extends TestCase
 {

--- a/tests/Unit/RfcFakerTest.php
+++ b/tests/Unit/RfcFakerTest.php
@@ -11,9 +11,9 @@ namespace PhpCfdi\Rfc\Tests\Unit;
 
 use PhpCfdi\Rfc\Rfc;
 use PhpCfdi\Rfc\RfcFaker;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
-class RfcFakerTest extends TestCase
+final class RfcFakerTest extends TestCase
 {
     /** @var number of times to run fakes */
     private $iterations = 100;

--- a/tests/Unit/RfcIntConverterTest.php
+++ b/tests/Unit/RfcIntConverterTest.php
@@ -12,7 +12,7 @@ namespace PhpCfdi\Rfc\Tests\Unit;
 use PhpCfdi\Rfc\Exceptions\InvalidIntegerToConvertException;
 use PhpCfdi\Rfc\Rfc;
 use PhpCfdi\Rfc\RfcIntConverter;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
 final class RfcIntConverterTest extends TestCase
 {

--- a/tests/Unit/RfcParserTest.php
+++ b/tests/Unit/RfcParserTest.php
@@ -8,7 +8,7 @@ namespace PhpCfdi\Rfc\Tests\Unit;
 
 use PhpCfdi\Rfc\Exceptions\InvalidExpressionToParseException;
 use PhpCfdi\Rfc\RfcParser;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
 final class RfcParserTest extends TestCase
 {

--- a/tests/Unit/RfcTest.php
+++ b/tests/Unit/RfcTest.php
@@ -8,7 +8,7 @@ namespace PhpCfdi\Rfc\Tests\Unit;
 
 use PhpCfdi\Rfc\Exceptions\InvalidExpressionToParseException;
 use PhpCfdi\Rfc\Rfc;
-use PHPUnit\Framework\TestCase;
+use PhpCfdi\Rfc\Tests\TestCase;
 
 final class RfcTest extends TestCase
 {


### PR DESCRIPTION
- Se actualiza el año en el archivo de licencia. Feliz 2022.
- Se actualizan las herramientas de desarrollo.
- Se actualiza el archivo de configuración de Psalm, el atributo `totallyTyped` está deprecado.
- Se agrega PHP 8.1 a la matriz de pruebas de PHP.
- Se crea la clase abstracta `PhpCfdi\Rfc\Tests\TestCase` para no depender directamente de `PHPUnit\Framework\TestCase`.