### PR TITLE
Refactorizando la generación del checksum

### DIFF
--- a/src/CheckSum.php
+++ b/src/CheckSum.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Rfc;
 
 final class CheckSum
 {
-    private static $DICTIONARY = [];
+    private array $dictionary;
 
     /**
      * Se encarga de generar el diccionario a usar.
@@ -14,12 +14,11 @@ final class CheckSum
     public function __construct()
     {
         $dictionary = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ #';
-        if (count(self::$DICTIONARY) > 0) {
-            return;
-        }
+        $dic = [];
         foreach (str_split($dictionary) as $index => $char) {
-            self::$DICTIONARY[$char] = $index;
+            $dic = array_merge($dic, [$char => $index]);
         }
+        $this->dictionary = $dic;
     }
 
     public function calculate(string $rfc): string
@@ -30,7 +29,7 @@ final class CheckSum
         array_pop($chars); // remove predefined checksum
         $sum = (12 === $length) ? 481 : 0; // 481 para morales, 0 para físicas
         foreach ($chars as $i => $char) {
-            $posChar = self::$DICTIONARY[$char];
+            $posChar = intval($this->dictionary[$char]);
             $factor = $length - $i;
             $sum += $posChar * $factor;
         }

--- a/src/CheckSum.php
+++ b/src/CheckSum.php
@@ -6,25 +6,26 @@ namespace PhpCfdi\Rfc;
 
 final class CheckSum
 {
-    private const DICTIONARY = [0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6, 7 => 7, 8 => 8, 9 => 9, 'A' => 10, 'B' => 11, 'C' => 12, 'D' => 13, 'E' => 14, 'F' => 15, 'G' => 16, 'H' => 17, 'I' => 18, 'J' => 19, 'K' => 20, 'L' => 21, 'M' => 22, 'N' => 23, '&' => 24, 'O' => 25, 'P' => 26, 'Q' => 27, 'R' => 28, 'S' => 29, 'T' => 30, 'U' => 31, 'V' => 32, 'W' => 33, 'X' => 34, 'Y' => 35, 'Z' => 36, ' ' => 37, '#' => 38];
+    private const DICTIONARY = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ #';
 
     public function calculate(string $rfc): string
     {
         // 'Ñ' translated to '#' because 'Ñ' is multibyte 0xC3 0xB1
-        $chars = str_split(str_replace('Ñ', '#', $rfc), 1);
-        array_pop($chars); // remove predefined checksum
+        $chars = str_split(str_replace('Ñ', '#', $rfc));
         $length = count($chars);
-        $sum = (11 === $length) ? 481 : 0; // 481 para morales, 0 para físicas
-        $j = $length + 1;
+        array_pop($chars); // remove predefined checksum
+        $sum = (12 === $length) ? 481 : 0; // 481 para morales, 0 para físicas
         foreach ($chars as $i => $char) {
-            $sum += self::DICTIONARY[$char] * ($j - $i);
+            $posChar = strpos(self::DICTIONARY, $char);
+            $factor = $length - $i;
+            $sum += $posChar * $factor;
         }
-        $digit = strval(11 - $sum % 11);
-        if ('11' === $digit) {
-            $digit = '0';
-        } elseif ('10' === $digit) {
-            $digit = 'A';
+        $mod11 = $sum % 11;
+        if ($mod11 === 0) {
+          return '0';
+        } else if($mod11 === 1) {
+          return 'A';
         }
-        return $digit;
+        return strval(11 - $mod11);
     }
 }

--- a/src/CheckSum.php
+++ b/src/CheckSum.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Rfc;
 
 final class CheckSum
 {
-    private $dictionary;
+    private $dictionary = [];
 
     /**
      * Se encarga de generar el diccionario a usar.

--- a/src/CheckSum.php
+++ b/src/CheckSum.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Rfc;
 
 final class CheckSum
 {
-    private array $dictionary;
+    private $dictionary;
 
     /**
      * Se encarga de generar el diccionario a usar.

--- a/src/CheckSum.php
+++ b/src/CheckSum.php
@@ -6,7 +6,21 @@ namespace PhpCfdi\Rfc;
 
 final class CheckSum
 {
-    private const DICTIONARY = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ #';
+    private static $DICTIONARY = [];
+
+    /**
+     * Se encarga de generar el diccionario a usar.
+     */
+    public function __construct()
+    {
+        $dictionary = '0123456789ABCDEFGHIJKLMN&OPQRSTUVWXYZ #';
+        if (count(self::$DICTIONARY) > 0) {
+            return;
+        }
+        foreach (str_split($dictionary) as $index => $char) {
+            self::$DICTIONARY[$char] = $index;
+        }
+    }
 
     public function calculate(string $rfc): string
     {
@@ -16,15 +30,15 @@ final class CheckSum
         array_pop($chars); // remove predefined checksum
         $sum = (12 === $length) ? 481 : 0; // 481 para morales, 0 para físicas
         foreach ($chars as $i => $char) {
-            $posChar = strpos(self::DICTIONARY, $char);
+            $posChar = self::$DICTIONARY[$char];
             $factor = $length - $i;
             $sum += $posChar * $factor;
         }
         $mod11 = $sum % 11;
         if ($mod11 === 0) {
-          return '0';
-        } else if($mod11 === 1) {
-          return 'A';
+            return '0';
+        } elseif ($mod11 === 1) {
+            return 'A';
         }
         return strval(11 - $mod11);
     }


### PR DESCRIPTION
Hola buenas,

Hice pequeñas modificaciones al código, como:

 - Remplazar el diccionario de un arreglo a un string.
 - El antiguo `$j` originalmente era la longitud mas uno, pero... si extraemos la longitud antes de realizar el pop ya no es necesario sumar la unidad.
 - Finalmente vi que la diferencia del once menos el modulo(11), solamente se utiliza para caso en donde el resultado de la operación cuando el modulo es distinto de cero y uno.

Respecto a la implementación del algoritmo vi esta documentación:

https://www.studocu.com/es-mx/document/universidad-del-valle-de-mexico/administracion/algoritmo-para-generar-el-rfc-con-homoclave-para-personas-fisicas-y-morales/12002840

Pero... me llama la atención que en el anexo I, veo diferencias en la tabla de caracteres(diccionario), no sé si tengas mayor información que pueda revisar y aclarar mis dudas.

Gracias.


