### PR TITLE
Mantenimiento 2025-09-25

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
-# SonarSource/sonarqube-scan-action@v5 https://github.com/marketplace/actions/official-sonarqube-scan
+# SonarSource/sonarqube-scan-action@v6 https://github.com/marketplace/actions/official-sonarqube-scan
 
 jobs:
 
@@ -137,6 +137,6 @@ jobs:
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/junit.xml > build/sonar-junit.xml
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/clover.xml > build/sonar-coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="php-cs-fixer" version="^3.75.0" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.12.1" installed="3.12.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.12.1" installed="3.12.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^4.0.0" installed="4.0.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.0" installed="4.0.0" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^2.1.11" installed="2.1.11" location="./tools/phpstan" copy="false"/>
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,6 +18,7 @@ return (new PhpCsFixer\Config())
         '@PHP81Migration' => true,
         '@PHP80Migration:risky' => true,
         // symfony
+        'array_indentation' => true,
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ Utilizamos [Versionado Semántico 2.0.0](SEMVER.md).
 
 Los cambios no liberados no requieren de una nueva versión y son incluidos en la rama principal.
 
+### Mantenimiento 2025-09-26
+
+- Se actualizan las herramientas `phpcs` y `phpcbf` a la versión 4.0.0.
+- Se elimina la regla `Generic.Functions.CallTimePassByReference`.
+- Se actualiza `sonarqube-scan-action` a la versión 6.
+
 ## Versión 1.2.0
 
 - Se asegura la compatibilidad con PHP 8.4.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>
@@ -11,9 +11,7 @@
     <arg name="extensions" value="php"/>
     <arg name="cache" value="build/phpcs.cache"/>
 
-    <rule ref="PSR12">
-        <exclude name="Generic.Files.LineLength.TooLong"/>
-    </rule>
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
@@ -29,4 +27,10 @@
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
     <rule ref="Zend.Files.ClosingTag"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="600"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
- Se actualizan las herramientas `phpcs` y `phpcbf` a la versión 4.0.0.
- Se elimina la regla `Generic.Functions.CallTimePassByReference`.
- Se actualiza `sonarqube-scan-action` a la versión 6.